### PR TITLE
Add a timer on level done for a chance to pick up remaining pickups.

### DIFF
--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -6,6 +6,7 @@ class_name Game
 @onready var bullet_manager = $BulletManager as BulletManager
 @onready var respawn_timer = $RespawnTimer as Timer
 @onready var level_done_check_timer = $LevelDoneCheckTimer as Timer
+@onready var level_done_timer = $LevelDoneTimer as Timer
 @onready var camera = $Camera as ShakeableCamera
 @onready var focus_point = $FocusPoint as Node2D
 @onready var hud = $HUD as HUD
@@ -279,17 +280,17 @@ func check_level_done() -> bool:
 	if Globals.stage_done:
 		return true
 	
-	for node in get_tree().get_nodes_in_group("Pickup"):
-		if not node is Pickup:
-			continue
-		if not Globals.in_visible_viewport(node.position):
-			continue
-		# TODO why doesn't this work? deferred?
-		player.pickup(node as Pickup)
-		print("Picking up " + str(node))
-
-	Globals.stage_done = true
 	level_done_check_timer.stop()
+	print("Level about to be done…")
+	
+	level_done_timer.start()
+	
+	return true
+
+func _on_level_done_timer_timeout():
+	level_done_timer.stop()
+	
+	Globals.stage_done = true
 	print("Level done!")
 	
 	if current_level < levels.size() - 1:
@@ -298,8 +299,6 @@ func check_level_done() -> bool:
 		stage_clear.display(score, current_level + 1)
 	else:
 		call_deferred("load_level", current_level + 1)
-	
-	return true
 
 
 func trigger_game_over(won: bool) -> void:

--- a/scenes/game/game.tscn
+++ b/scenes/game/game.tscn
@@ -18,6 +18,9 @@ one_shot = true
 
 [node name="LevelDoneCheckTimer" type="Timer" parent="."]
 
+[node name="LevelDoneTimer" type="Timer" parent="."]
+wait_time = 5.0
+
 [node name="BulletManager" type="Node2D" parent="."]
 script = ExtResource("5_7ft26")
 
@@ -49,6 +52,7 @@ visible = false
 
 [connection signal="timeout" from="RespawnTimer" to="." method="_on_respawn_timer_timeout"]
 [connection signal="timeout" from="LevelDoneCheckTimer" to="." method="_on_level_done_check_timer_timeout"]
+[connection signal="timeout" from="LevelDoneTimer" to="." method="_on_level_done_timer_timeout"]
 [connection signal="died" from="Player" to="." method="_on_player_died"]
 [connection signal="drone_died" from="Player" to="." method="_on_player_drone_died"]
 [connection signal="healed" from="Player" to="." method="_on_player_healed"]


### PR DESCRIPTION
Since we talked on Mastodon, I thought I’d give it a try, for research purposes. I get nerd sniped so easily.

It’s basically splitting `check_level_done` into two functions: the new `check_level_done` that doesn’t automatically pick up remaining items anymore, and doesn’t trigger the end of level either. Instead, it starts a timer that fires `_on_level_done_timer_timeout` after 5 seconds, which triggers the end of level (and if you forget to stop the timer, then the game becomes much easier to finish 😃 .)